### PR TITLE
Fix newsletter hebdo template

### DIFF
--- a/ecosante/inscription/models.py
+++ b/ecosante/inscription/models.py
@@ -191,6 +191,10 @@ class Inscription(db.Model):
     def has_enfants(self):
         return self.enfants == 'oui'
 
+    @property
+    def has_animaux_domestiques(self):
+        return type(self.animaux_domestiques) == list and ('chat' or 'chien') in self.animaux_domestiques
+
     def set_cache_api_commune(self):
         if not self.ville_insee:
             return

--- a/ecosante/newsletter/models.py
+++ b/ecosante/newsletter/models.py
@@ -71,15 +71,21 @@ class NewsletterHebdoTemplate(db.Model):
     @classmethod
     def next_template(cls, inscription: Inscription, templates=None):
         templates = templates or cls.get_templates()
-        valid_templates = [t for t in templates if t.filtre_date(date.today()) and t.filtre_criteres(inscription)]
+        already_sent_templates_ids = [nl.newsletter_hebdo_template_id for nl in inscription.last_newsletters_hebdo]
+        valid_templates = sorted(
+            [
+                t
+                for t in templates
+                if t.filtre_date(date.today())\
+                    and t.filtre_criteres(inscription)\
+                    and t.id not in already_sent_templates_ids
+            ],
+            key=lambda t: t.ordre
+        )
         if len(valid_templates) == 0:
             return None
-        if len(inscription.last_newsletters_hebdo) == 0:
-            return valid_templates[0]
-        dernier_ordre = inscription.last_newsletters_hebdo[0].newsletter_hebdo_template.ordre
-        if dernier_ordre >= max([t.ordre for t in valid_templates]):
-            return None
-        return [t for t in valid_templates if t.ordre > dernier_ordre][0]
+
+        return [t for t in valid_templates][0]
 
     @property
     def periode_validite(self) -> DateRange:

--- a/ecosante/newsletter/models.py
+++ b/ecosante/newsletter/models.py
@@ -50,6 +50,10 @@ class NewsletterHebdoTemplate(db.Model):
         return cls.query.order_by(cls.ordre).all()
 
     def filtre_date(self, date_):
+        periode_validite = self.periode_validite
+        if periode_validite.lower.year != periode_validite.upper.year:
+            return date(date_.year, 1, 1) <= date_ <= periode_validite.upper.replace(year=date_.year)\
+                 or  periode_validite.lower.replace(year=date_.year) <= date_ <= date(date_.year, 12, 31)
         return date_ in self.periode_validite
 
     def filtre_criteres(self, inscription):
@@ -80,7 +84,7 @@ class NewsletterHebdoTemplate(db.Model):
     @property
     def periode_validite(self) -> DateRange:
         current_year = datetime.today().year
-        if date(current_year, self._periode_validite.lower.month, self._periode_validite.lower.day) <= date(current_year, self._periode_validite.upper.month, self._periode_validite.upper.day):
+        if self._periode_validite.lower.replace(year=current_year) <= self._periode_validite.upper.replace(year=current_year):
             year_lower = current_year
         else:
             year_lower = current_year - 1

--- a/ecosante/newsletter/models.py
+++ b/ecosante/newsletter/models.py
@@ -61,11 +61,14 @@ class NewsletterHebdoTemplate(db.Model):
             critere = getattr(self, nom_critere)
             if isinstance(critere, list) and len(critere) > 0:
                 inscription_critere = getattr(inscription, nom_critere)
-                return isinstance(inscription_critere, list) and len(set(critere).intersection(inscription_critere)) > 0
-        if isinstance(self.enfants, bool):
-            return self.enfants == inscription.has_enfants
-        if isinstance(self.animaux_domestiques, bool):
-            return self.animaux_domestiques == inscription.has_animaux_domestiques
+                if not isinstance(inscription_critere, list):
+                    return False
+                if len(set(critere).intersection(inscription_critere)) == 0:
+                    return False
+        if isinstance(self.enfants, bool) and self.enfants != inscription.has_enfants:
+            return False
+        if isinstance(self.animaux_domestiques, bool) and self.animaux_domestiques != inscription.has_animaux_domestiques:
+            return False
         return True
 
     @classmethod

--- a/ecosante/newsletter/models.py
+++ b/ecosante/newsletter/models.py
@@ -75,7 +75,7 @@ class NewsletterHebdoTemplate(db.Model):
         dernier_ordre = inscription.last_newsletters_hebdo[0].newsletter_hebdo_template.ordre
         if dernier_ordre >= max([t.ordre for t in valid_templates]):
             return None
-        return [t for t in templates if t.ordre > dernier_ordre][0]
+        return [t for t in valid_templates if t.ordre > dernier_ordre][0]
 
     @property
     def periode_validite(self) -> DateRange:

--- a/ecosante/newsletter/models.py
+++ b/ecosante/newsletter/models.py
@@ -96,7 +96,6 @@ class NewsletterHebdoTemplate(db.Model):
             year_lower = current_year - 1
         # Si les dates sont sur deux années différentes ont veut conserver le saut d’année
         year_upper = year_lower + (self._periode_validite.upper.year - self._periode_validite.lower.year)
-        print(DateRange(self._periode_validite.lower.replace(year=year_lower), self._periode_validite.upper.replace(year=year_upper)))
         return DateRange(self._periode_validite.lower.replace(year=year_lower), self._periode_validite.upper.replace(year=year_upper))
 
     @property

--- a/ecosante/newsletter/models.py
+++ b/ecosante/newsletter/models.py
@@ -63,9 +63,9 @@ class NewsletterHebdoTemplate(db.Model):
                 inscription_critere = getattr(inscription, nom_critere)
                 return isinstance(inscription_critere, list) and len(set(critere).intersection(inscription_critere)) > 0
         if isinstance(self.enfants, bool):
-            return self.enfants == inscription.enfants
+            return self.enfants == inscription.has_enfants
         if isinstance(self.animaux_domestiques, bool):
-            return self.animaux_domestiques == inscription.animaux_domestiques
+            return self.animaux_domestiques == inscription.has_animaux_domestiques
         return True
 
     @classmethod
@@ -96,6 +96,7 @@ class NewsletterHebdoTemplate(db.Model):
             year_lower = current_year - 1
         # Si les dates sont sur deux années différentes ont veut conserver le saut d’année
         year_upper = year_lower + (self._periode_validite.upper.year - self._periode_validite.lower.year)
+        print(DateRange(self._periode_validite.lower.replace(year=year_lower), self._periode_validite.upper.replace(year=year_upper)))
         return DateRange(self._periode_validite.lower.replace(year=year_lower), self._periode_validite.upper.replace(year=year_upper))
 
     @property

--- a/tests/test_newsletter.py
+++ b/tests/test_newsletter.py
@@ -563,7 +563,7 @@ def test_export_user_hebdo_ordre(db_session, inscription, templates):
     nl1 = Newsletter(
         inscription=inscription,
         date=yesterday,
-        newsletter_hebdo_template=templates[1]
+        newsletter_hebdo_template=min(templates, key=lambda t: t.ordre)
     )
     db_session.add(NewsletterDB(nl1))
     db_session.commit()

--- a/tests/test_newsletter_hedbo.py
+++ b/tests/test_newsletter_hedbo.py
@@ -96,12 +96,14 @@ def test_periode_validite_contains_periode_validite_two_years(db_session, templa
     db_session.add(t)
     db_session.commit()
 
-    assert t.filtre_date(date.today().replace(month=1, day=1)) == False
+    assert t.filtre_date(date.today().replace(month=1, day=1))
     assert t.filtre_date(date.today().replace(month=10, day=1))
     assert t.filtre_date(date.today().replace(month=10, day=10))
     assert t.filtre_date(date.today().replace(month=12, day=31))
     assert t.filtre_date(date.today().replace(year=date.today().year+1, month=1, day=1))
-    assert t.filtre_date(date.today().replace(year=date.today().year+1, month=1, day=31))
+    assert t.filtre_date(date.today().replace(year=date.today().year+1, month=2, day=1))
+    assert t.filtre_date(date.today().replace(year=date.today().year+1, month=2, day=2)) == False
+    assert t.filtre_date(date.today().replace(month=9, day=30)) == False
 
 def test_chauffage(templates, inscription):
     t = templates[0]

--- a/tests/test_newsletter_hedbo.py
+++ b/tests/test_newsletter_hedbo.py
@@ -14,16 +14,16 @@ def test_next_template_first(db_session, inscription, templates):
     assert NewsletterHebdoTemplate.next_template(inscription) != None
 
 def test_next_template(db_session, inscription, templates):
-    template = templates[1]
+    template = min(templates, key=lambda t: t.ordre)
     nl = Newsletter(inscription=inscription, newsletter_hebdo_template=template)
     db_session.add(NewsletterDB(nl))
 
     assert NewsletterHebdoTemplate.next_template(inscription).ordre > template.ordre 
 
 def test_next_template_last(db_session, inscription, templates):
-    template = templates[0]
-    nl = Newsletter(inscription=inscription, newsletter_hebdo_template=template)
-    db_session.add(NewsletterDB(nl))
+    for template in templates:
+        nl = Newsletter(inscription=inscription, newsletter_hebdo_template=template)
+        db_session.add(NewsletterDB(nl))
 
     assert NewsletterHebdoTemplate.next_template(inscription) == None
 

--- a/tests/test_newsletter_hedbo.py
+++ b/tests/test_newsletter_hedbo.py
@@ -107,16 +107,19 @@ def test_periode_validite_contains_periode_validite_two_years(db_session, templa
 
 def test_chauffage(templates, inscription):
     t = templates[0]
-
+    t.chauffage = []
+    assert t.filtre_criteres(inscription) == True
+    inscription.chauffage = ["bois"]
     assert t.filtre_criteres(inscription) == True
 
     t.chauffage = ["bois"]
+    inscription.chauffage = None
     assert t.filtre_criteres(inscription) == False
     inscription.chauffage = ["bois"]
     assert t.filtre_criteres(inscription) == True
 
     t.chauffage = ["bois", "chaudiere"]
-    inscription.chauffage = []
+    inscription.chauffage = None
     assert t.filtre_criteres(inscription) == False
     inscription.chauffage = ["bois"]
     assert t.filtre_criteres(inscription) == True
@@ -127,62 +130,86 @@ def test_chauffage(templates, inscription):
 
 def test_activites(templates, inscription):
     t = templates[0]
-
+    t.activites = []
+    assert t.filtre_criteres(inscription) == True
+    inscription.activites = ["menage"]
     assert t.filtre_criteres(inscription) == True
 
     t.activites = ["menage"]
+    inscription.activites = None
     assert t.filtre_criteres(inscription) == False
     inscription.activites = ["menage"]
     assert t.filtre_criteres(inscription) == True
 
+    t.activites = ["menage", "bricolage"]
+    inscription.activites = None
+    assert t.filtre_criteres(inscription) == False
+    inscription.activites = ["menage"]
+    assert t.filtre_criteres(inscription) == True
+    inscription.activites = ["bricolage"]
+    assert t.filtre_criteres(inscription) == True
+    inscription.activites = ["bricolage", "menage"]
+    assert t.filtre_criteres(inscription) == True
+
 def test_enfants(templates, inscription):
     t = templates[0]
-
+    t.enfants = None
+    assert t.filtre_criteres(inscription) == True
+    inscription.enfants = "oui"
     assert t.filtre_criteres(inscription) == True
 
     t.enfants = True
+    inscription.enfants = "non"
     assert t.filtre_criteres(inscription) == False
-    inscription.enfants = True
+    inscription.enfants = "oui"
     assert t.filtre_criteres(inscription) == True
 
-    inscription.enfants = None
     t.enfants = False
+    inscription.enfants = "oui"
     assert t.filtre_criteres(inscription) == False
-    inscription.enfants = False
+    inscription.enfants = "non"
     assert t.filtre_criteres(inscription) == True
 
 def test_deplacement(templates, inscription):
     t = templates[0]
-
-    t.deplacement = None
+    t.deplacement = []
     assert t.filtre_criteres(inscription) == True
     inscription.deplacement = ["velo"]
     assert t.filtre_criteres(inscription) == True
 
-    t.deplacement = ["voiture"]
+    t.deplacement = ["velo"]
+    inscription.deplacement = None
     assert t.filtre_criteres(inscription) == False
-    inscription.deplacement = ["voiture"]
+    inscription.deplacement = ["velo"]
     assert t.filtre_criteres(inscription) == True
 
     t.deplacement = ["velo", "tec"]
+    inscription.deplacement = None
     assert t.filtre_criteres(inscription) == False
-    inscription.deplacement = ["velo", "tec"]
+    inscription.deplacement = ["velo"]
+    assert t.filtre_criteres(inscription) == True
+    inscription.deplacement = ["tec"]
+    assert t.filtre_criteres(inscription) == True
+    inscription.deplacement = ["tec", "velo"]
     assert t.filtre_criteres(inscription) == True
 
 def test_animaux_domestiques(templates, inscription):
     t = templates[0]
-
+    t.animaux_domestiques = None
+    assert t.filtre_criteres(inscription) == True
+    inscription.animaux_domestiques = ["chat"]
     assert t.filtre_criteres(inscription) == True
 
     t.animaux_domestiques = True
+    inscription.animaux_domestiques = None
     assert t.filtre_criteres(inscription) == False
-    inscription.animaux_domestiques = True
+    inscription.animaux_domestiques = ["chat"]
     assert t.filtre_criteres(inscription) == True
 
-    inscription.animaux_domestiques = None
     t.animaux_domestiques = False
+    inscription.animaux_domestiques = ["chat"]
     assert t.filtre_criteres(inscription) == False
-    inscription.animaux_domestiques = False
+    inscription.animaux_domestiques = None
     assert t.filtre_criteres(inscription) == True
 
 def test_vraie_vie(templates, inscription, db_session):

--- a/tests/test_newsletter_hedbo.py
+++ b/tests/test_newsletter_hedbo.py
@@ -212,6 +212,18 @@ def test_animaux_domestiques(templates, inscription):
     inscription.animaux_domestiques = None
     assert t.filtre_criteres(inscription) == True
 
+def test_deux_criteres(templates, inscription):
+    t = templates[0]
+    t.animaux_domestiques = True
+    t.deplacement = ['velo']
+
+    assert t.filtre_criteres(inscription) == False
+    inscription.animaux_domestiques = ["chat"]
+    assert t.filtre_criteres(inscription) == False
+    inscription.deplacement = ["velo"]
+    assert t.filtre_criteres(inscription) == True
+
+
 def test_vraie_vie(templates, inscription, db_session):
     templates = sorted(templates, key=lambda n: n.ordre)
     templates[1].animaux_domestiques = True

--- a/tests/test_newsletter_hedbo.py
+++ b/tests/test_newsletter_hedbo.py
@@ -182,3 +182,23 @@ def test_animaux_domestiques(templates, inscription):
     assert t.filtre_criteres(inscription) == False
     inscription.animaux_domestiques = False
     assert t.filtre_criteres(inscription) == True
+
+def test_vraie_vie(templates, inscription, db_session):
+    templates = sorted(templates, key=lambda n: n.ordre)
+    templates[1].animaux_domestiques = True
+    templates[2].enfants = True
+    templates[3].chauffage = ["bois"]
+
+    db_session.add(inscription)
+    db_session.add_all(templates)
+    db_session.commit()
+
+    nls = list(Newsletter.export(type_='hebdomadaire'))
+    assert len(nls) == 1
+    assert nls[0].newsletter_hebdo_template.id == templates[0].id
+    db_session.add_all([NewsletterDB(nl) for nl in nls])
+    db_session.commit()
+
+    nls = list(Newsletter.export(type_='hebdomadaire', filter_already_sent=False))
+    assert len(nls) == 1
+    assert nls[0].newsletter_hebdo_template.id == templates[-1].id


### PR DESCRIPTION
Il y a quatre choses dans cette PR : 

1) Fix dans les dates, si on a une date qui fait un _passe 31 décembre_, on vérifie d’abord pour la période 1ier janvier, jusqu’à la borne supérieure, puis on vérifie de la date de début jusqu’au 31 décembre. Je pense que ça va résoudre des problèmes, tout du moins j’ai puis fixé des tests

2) On n’utilisait pas les templates filtrés dans next_template_filter...

3) On a vu qu’on a des bugs dans la base de données, avec certaines personnes qui n’ont pas reçues les premières newsletter hebdo, on envoie maintenant la première newsletter non reçue.

4) @fcoufour a corrigé des problèmes dans les tests