### PR TITLE
Changement NewsletterHebdoTemplate

### DIFF
--- a/ecosante/newsletter/forms/newsletter_hebdo.py
+++ b/ecosante/newsletter/forms/newsletter_hebdo.py
@@ -28,11 +28,5 @@ class FormTemplateAdd(BaseForm):
         ],
     )
 
-    def validate_ordre(form, field):
-        template_same_ordre = NewsletterHebdoTemplate.query.filter_by(ordre=field.data).first()
-        if template_same_ordre:
-            if not 'id' in form.data or int(form.data['id']) != template_same_ordre.id:
-                raise ValidationError("Un autre template a déjà cet ordre")
-
 class FormTemplateEdit(FormTemplateAdd):
     id = HiddenField()

--- a/ecosante/newsletter/forms/newsletter_hebdo.py
+++ b/ecosante/newsletter/forms/newsletter_hebdo.py
@@ -18,15 +18,11 @@ class FormTemplateAdd(BaseForm):
     chauffage = FormEdit.chauffage
     deplacement = FormEdit.deplacement
     animaux_domestiques = FormEdit.animal_de_compagnie
-    indicateurs = MultiCheckboxField(
-        "Ne montrer qu’aux personnes inscrites aux indicateurs",
-        choices=[
-            ("raep", "Risque d’allergie aux pollens"),
-            ("indice_atmo", "Indice ATMO"),
-            ("vigilance_meteo", "Vigilance météo"),
-            ("indice_uv", "Indice UV")
-        ],
-    )
+
+    raep = OuiNonField("Montrer aux personnes recevant le RAEP ?")
+    indice_atmo = OuiNonField("Montrer aux personnes recevant l’indice ATMO ?")
+    vigilance_meteo = OuiNonField("Montrer aux personnes recevant la vigilance météo ?")
+    indice_uv = OuiNonField("Montrer aux personnes recevant l’indice UV ?")
 
 class FormTemplateEdit(FormTemplateAdd):
     id = HiddenField()

--- a/ecosante/newsletter/forms/newsletter_hebdo.py
+++ b/ecosante/newsletter/forms/newsletter_hebdo.py
@@ -19,10 +19,10 @@ class FormTemplateAdd(BaseForm):
     deplacement = FormEdit.deplacement
     animaux_domestiques = FormEdit.animal_de_compagnie
 
-    indice_atmo = OuiNonField("Montrer aux personnes recevant l’indice ATMO ?")
-    raep = OuiNonField("Montrer aux personnes recevant le RAEP ?")
-    vigilance_meteo = OuiNonField("Montrer aux personnes recevant la vigilance météo ?")
-    indice_uv = OuiNonField("Montrer aux personnes recevant l’indice UV ?")
+    indice_atmo = OuiNonField("Inclure (Oui) ou exclure (Non) les abonnés à l’indice ATMO ?")
+    raep = OuiNonField("Inclure (Oui) ou exclure (Non) les abonnés RAEP ?")
+    vigilance_meteo = OuiNonField("Inclure (Oui) ou exclure (Non) les abonnés à la vigilance météo ?")
+    indice_uv = OuiNonField("Inclure (Oui) ou exclure (Non) les abonnés à l’indice UV ?")
 
 class FormTemplateEdit(FormTemplateAdd):
     id = HiddenField()

--- a/ecosante/newsletter/forms/newsletter_hebdo.py
+++ b/ecosante/newsletter/forms/newsletter_hebdo.py
@@ -19,8 +19,8 @@ class FormTemplateAdd(BaseForm):
     deplacement = FormEdit.deplacement
     animaux_domestiques = FormEdit.animal_de_compagnie
 
-    raep = OuiNonField("Montrer aux personnes recevant le RAEP ?")
     indice_atmo = OuiNonField("Montrer aux personnes recevant l’indice ATMO ?")
+    raep = OuiNonField("Montrer aux personnes recevant le RAEP ?")
     vigilance_meteo = OuiNonField("Montrer aux personnes recevant la vigilance météo ?")
     indice_uv = OuiNonField("Montrer aux personnes recevant l’indice UV ?")
 

--- a/ecosante/newsletter/models.py
+++ b/ecosante/newsletter/models.py
@@ -27,6 +27,12 @@ from indice_pollution.history.models import IndiceUv
 FR_DATE_FORMAT = '%d/%m/%Y'
 
 
+def property_indicateur(indicateur):
+    return property(
+        lambda self: self.indicateur_getter(indicateur),
+        lambda self, value: self.indicateur_setter(value, indicateur)
+    )
+
 @dataclass
 class NewsletterHebdoTemplate(db.Model):
     id: int = db.Column(db.Integer, primary_key=True)
@@ -39,6 +45,7 @@ class NewsletterHebdoTemplate(db.Model):
     chauffage: List[str] = db.Column(postgresql.ARRAY(db.String))
     _animaux_domestiques: List[str] = db.Column("animaux_domestiques", postgresql.ARRAY(db.String))
     indicateurs: List[str] = db.Column(postgresql.ARRAY(db.String))
+    indicateurs_exclus: List[str] = db.Column(postgresql.ARRAY(db.String))
 
     _periode_validite: DateRange = db.Column(
         "periode_validite",
@@ -71,11 +78,10 @@ class NewsletterHebdoTemplate(db.Model):
             return False
         if isinstance(self.animaux_domestiques, bool) and self.animaux_domestiques != inscription.has_animaux_domestiques:
             return False
-        if isinstance(self.indicateurs, list) and len(self.indicateurs) > 0:
-            if not isinstance(inscription.indicateurs, list):
-                return False
-            if len(set(inscription.indicateurs).intersection(set(self.indicateurs))) == 0:
-                return False
+        if all([indicateur in inscription.indicateurs for indicateur in self.indicateurs]):
+            return False
+        if not any([indicateur in inscription.indicateurs for indicateur in self.indicateurs_exclus]):
+            return False
         return True
 
     @classmethod
@@ -154,6 +160,33 @@ class NewsletterHebdoTemplate(db.Model):
             self._enfants = ["true" if value else "false"]
         else:
             self._enfants = None
+
+    def indicateur_setter(self, value, indicateur):
+        if value == None:
+            self.indicateurs = list(set(self.indicateurs or []) - set([indicateur]))
+            self.indicateurs_exclus = list(set(self.indicateurs_exclus or []) - set([indicateur]))
+        elif value == False:
+            self.indicateurs = list(set(self.indicateurs or []) - set([indicateur]))
+            self.indicateurs_exclus = list(set(self.indicateurs_exclus or []) | set([indicateur]))
+        elif value == True:
+            self.indicateurs = list(set(self.indicateurs or []) | set([indicateur]))
+            self.indicateurs_exclus = list(set(self.indicateurs_exclus or []) - set([indicateur]))
+
+    def indicateur_getter(self, indicateur):
+        if not isinstance(self.indicateurs, list):
+            return None
+        if indicateur in self.indicateurs:
+            return True
+        elif indicateur in self.indicateurs_exclus:
+            return False
+        else:
+            return None
+
+    raep = property_indicateur("raep")
+    indice_atmo = property_indicateur("indice_atmo")
+    vigilance_meteo = property_indicateur("vigilance_meteo")
+    indice_uv = property_indicateur("indice_uv")
+
 
 @dataclass
 class Newsletter:

--- a/ecosante/newsletter/models.py
+++ b/ecosante/newsletter/models.py
@@ -79,16 +79,20 @@ class NewsletterHebdoTemplate(db.Model):
         return True
 
     @classmethod
-    def next_template(cls, inscription: Inscription, templates=None):
+    def next_template(cls, inscription: Inscription, templates=None) -> 'NewsletterHebdoTemplate | None':
         templates = templates or cls.get_templates()
-        already_sent_templates_ids = [nl.newsletter_hebdo_template_id for nl in inscription.last_newsletters_hebdo]
+        template_id_ordre = {t.id: t.ordre for t in templates}
+        already_sent_templates_ordres = [
+            template_id_ordre[nl.newsletter_hebdo_template_id] 
+            for nl in inscription.last_newsletters_hebdo
+        ]
         valid_templates = sorted(
             [
                 t
                 for t in templates
                 if t.filtre_date(date.today())\
+                    and t.ordre not in already_sent_templates_ordres
                     and t.filtre_criteres(inscription)\
-                    and t.id not in already_sent_templates_ids
             ],
             key=lambda t: t.ordre
         )

--- a/ecosante/newsletter/models.py
+++ b/ecosante/newsletter/models.py
@@ -78,9 +78,12 @@ class NewsletterHebdoTemplate(db.Model):
             return False
         if isinstance(self.animaux_domestiques, bool) and self.animaux_domestiques != inscription.has_animaux_domestiques:
             return False
-        if all([indicateur in inscription.indicateurs for indicateur in self.indicateurs]):
+        inscription_indicateurs = inscription.indicateurs if isinstance(inscription.indicateurs, list) else []
+        self_indicateurs = self.indicateurs if isinstance(self.indicateurs, list) else []
+        self_indicateurs_exclus = self.indicateurs_exclus if isinstance(self.indicateurs_exclus, list) else []
+        if not all([indicateur in inscription_indicateurs for indicateur in self_indicateurs]):
             return False
-        if not any([indicateur in inscription.indicateurs for indicateur in self.indicateurs_exclus]):
+        if any([indicateur in inscription_indicateurs for indicateur in self_indicateurs_exclus]):
             return False
         return True
 

--- a/ecosante/newsletter/templates/newsletter_hebdo_form.html
+++ b/ecosante/newsletter/templates/newsletter_hebdo_form.html
@@ -17,7 +17,10 @@
         {{ render_field(form.deplacement) }}
         {{ render_field(form.animaux_domestiques) }}
         {{ render_field(form.enfants) }}
-        {{ render_field(form.indicateurs) }}
+        {{ render_field(form.raep) }}
+        {{ render_field(form.indice_atmo) }}
+        {{ render_field(form.vigilance_meteo) }}
+        {{ render_field(form.indice_uv) }}
 
         <div class="form__group">
           <button class="button" type="submit" id="submit">Envoyer</button>

--- a/ecosante/newsletter/templates/newsletter_hebdo_form.html
+++ b/ecosante/newsletter/templates/newsletter_hebdo_form.html
@@ -17,8 +17,8 @@
         {{ render_field(form.deplacement) }}
         {{ render_field(form.animaux_domestiques) }}
         {{ render_field(form.enfants) }}
-        {{ render_field(form.raep) }}
         {{ render_field(form.indice_atmo) }}
+        {{ render_field(form.raep) }}
         {{ render_field(form.vigilance_meteo) }}
         {{ render_field(form.indice_uv) }}
 

--- a/migrations/versions/c8a957612479_ajout_newsletterhebdotemplate_.py
+++ b/migrations/versions/c8a957612479_ajout_newsletterhebdotemplate_.py
@@ -1,0 +1,24 @@
+"""Ajout newsletterhebdotemplate.indicateurs_exclus
+
+Revision ID: c8a957612479
+Revises: 6603bd49a22b
+Create Date: 2022-03-10 17:49:56.873891
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = 'c8a957612479'
+down_revision = '6603bd49a22b'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('newsletter_hebdo_template', sa.Column('indicateurs_exclus', postgresql.ARRAY(sa.String()), nullable=True))
+
+
+def downgrade():
+    op.drop_column('newsletter_hebdo_template', 'indicateurs_exclus')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -232,6 +232,10 @@ def template():
 @pytest.fixture(scope='function')
 def templates(db_session):
     templates = [
+        NewsletterHebdoTemplate(ordre=12, sib_id=14, _periode_validite=DateRange(date(2022,1, 1), date(2023, 1,1)), indicateurs=['indice_atmo', 'raep']),
+        NewsletterHebdoTemplate(ordre=12, sib_id=13, _periode_validite=DateRange(date(2022,1, 1), date(2023, 1,1)), indicateurs=['indice_atmo']),
+        NewsletterHebdoTemplate(ordre=11, sib_id=12, _periode_validite=DateRange(date(2022,1, 1), date(2023, 1,1)), enfants=True),
+        NewsletterHebdoTemplate(ordre=11, sib_id=11, _periode_validite=DateRange(date(2022,1, 1), date(2023, 1,1)), enfants=False),
         NewsletterHebdoTemplate(ordre=10, sib_id=10, _periode_validite=DateRange(date(2022,1, 1), date(2023, 1,1))),
         NewsletterHebdoTemplate(ordre=7, sib_id=7, _periode_validite=DateRange(date(2022,1, 1), date(2023, 1,1))),
 	    NewsletterHebdoTemplate(ordre=9, sib_id=9, _periode_validite=DateRange(date(2022,1, 1), date(2023, 1,1))),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -225,6 +225,11 @@ def raep_nul(db_session, commune_commited):
     return raep
 
 @pytest.fixture(scope='function')
+def template():
+    return NewsletterHebdoTemplate(ordre=1, sib_id=1, _periode_validite=DateRange(date(2022,1, 1), date(2023, 1,1)))
+
+
+@pytest.fixture(scope='function')
 def templates(db_session):
     templates = [
         NewsletterHebdoTemplate(ordre=10, sib_id=10, _periode_validite=DateRange(date(2022,1, 1), date(2023, 1,1))),

--- a/tests/test_newsletter_hedbo.py
+++ b/tests/test_newsletter_hedbo.py
@@ -334,7 +334,6 @@ def test_meme_ordre_population_recoupe(templates, inscription, db_session):
     nl.date = date.today() - timedelta(days=1)
     db_session.add(NewsletterDB(nl))
     db_session.commit()
-    inscription = Inscription.query.get(inscription.id)
 
     nlt = NewsletterHebdoTemplate.next_template(inscription)
     assert nlt == None or nlt.ordre > 12

--- a/tests/test_newsletter_hedbo.py
+++ b/tests/test_newsletter_hedbo.py
@@ -105,123 +105,117 @@ def test_periode_validite_contains_periode_validite_two_years(db_session, templa
     assert t.filtre_date(date.today().replace(year=date.today().year+1, month=2, day=2)) == False
     assert t.filtre_date(date.today().replace(month=9, day=30)) == False
 
-def test_chauffage(templates, inscription):
-    t = templates[0]
-    t.chauffage = []
-    assert t.filtre_criteres(inscription) == True
+def test_chauffage(template, inscription):
+    template.chauffage = []
+    assert template.filtre_criteres(inscription) == True
     inscription.chauffage = ["bois"]
-    assert t.filtre_criteres(inscription) == True
+    assert template.filtre_criteres(inscription) == True
 
-    t.chauffage = ["bois"]
+    template.chauffage = ["bois"]
     inscription.chauffage = None
-    assert t.filtre_criteres(inscription) == False
+    assert template.filtre_criteres(inscription) == False
     inscription.chauffage = ["bois"]
-    assert t.filtre_criteres(inscription) == True
+    assert template.filtre_criteres(inscription) == True
 
-    t.chauffage = ["bois", "chaudiere"]
+    template.chauffage = ["bois", "chaudiere"]
     inscription.chauffage = None
-    assert t.filtre_criteres(inscription) == False
+    assert template.filtre_criteres(inscription) == False
     inscription.chauffage = ["bois"]
-    assert t.filtre_criteres(inscription) == True
+    assert template.filtre_criteres(inscription) == True
     inscription.chauffage = ["chaudiere"]
-    assert t.filtre_criteres(inscription) == True
+    assert template.filtre_criteres(inscription) == True
     inscription.chauffage = ["chaudiere", "bois"]
-    assert t.filtre_criteres(inscription) == True
+    assert template.filtre_criteres(inscription) == True
 
-def test_activites(templates, inscription):
-    t = templates[0]
-    t.activites = []
-    assert t.filtre_criteres(inscription) == True
+def test_activites(template, inscription):
+    template.activites = []
+    assert template.filtre_criteres(inscription) == True
     inscription.activites = ["menage"]
-    assert t.filtre_criteres(inscription) == True
+    assert template.filtre_criteres(inscription) == True
 
-    t.activites = ["menage"]
+    template.activites = ["menage"]
     inscription.activites = None
-    assert t.filtre_criteres(inscription) == False
+    assert template.filtre_criteres(inscription) == False
     inscription.activites = ["menage"]
-    assert t.filtre_criteres(inscription) == True
+    assert template.filtre_criteres(inscription) == True
 
-    t.activites = ["menage", "bricolage"]
+    template.activites = ["menage", "bricolage"]
     inscription.activites = None
-    assert t.filtre_criteres(inscription) == False
+    assert template.filtre_criteres(inscription) == False
     inscription.activites = ["menage"]
-    assert t.filtre_criteres(inscription) == True
+    assert template.filtre_criteres(inscription) == True
     inscription.activites = ["bricolage"]
-    assert t.filtre_criteres(inscription) == True
+    assert template.filtre_criteres(inscription) == True
     inscription.activites = ["bricolage", "menage"]
-    assert t.filtre_criteres(inscription) == True
+    assert template.filtre_criteres(inscription) == True
 
-def test_enfants(templates, inscription):
-    t = templates[0]
-    t.enfants = None
-    assert t.filtre_criteres(inscription) == True
+def test_enfants(template, inscription):
+    template.enfants = None
+    assert template.filtre_criteres(inscription) == True
     inscription.enfants = "oui"
-    assert t.filtre_criteres(inscription) == True
+    assert template.filtre_criteres(inscription) == True
 
-    t.enfants = True
+    template.enfants = True
     inscription.enfants = "non"
-    assert t.filtre_criteres(inscription) == False
+    assert template.filtre_criteres(inscription) == False
     inscription.enfants = "oui"
-    assert t.filtre_criteres(inscription) == True
+    assert template.filtre_criteres(inscription) == True
 
-    t.enfants = False
+    template.enfants = False
     inscription.enfants = "oui"
-    assert t.filtre_criteres(inscription) == False
+    assert template.filtre_criteres(inscription) == False
     inscription.enfants = "non"
-    assert t.filtre_criteres(inscription) == True
+    assert template.filtre_criteres(inscription) == True
 
-def test_deplacement(templates, inscription):
-    t = templates[0]
-    t.deplacement = []
-    assert t.filtre_criteres(inscription) == True
+def test_deplacement(template, inscription):
+    template.deplacement = []
+    assert template.filtre_criteres(inscription) == True
     inscription.deplacement = ["velo"]
-    assert t.filtre_criteres(inscription) == True
+    assert template.filtre_criteres(inscription) == True
 
-    t.deplacement = ["velo"]
+    template.deplacement = ["velo"]
     inscription.deplacement = None
-    assert t.filtre_criteres(inscription) == False
+    assert template.filtre_criteres(inscription) == False
     inscription.deplacement = ["velo"]
-    assert t.filtre_criteres(inscription) == True
+    assert template.filtre_criteres(inscription) == True
 
-    t.deplacement = ["velo", "tec"]
+    template.deplacement = ["velo", "tec"]
     inscription.deplacement = None
-    assert t.filtre_criteres(inscription) == False
+    assert template.filtre_criteres(inscription) == False
     inscription.deplacement = ["velo"]
-    assert t.filtre_criteres(inscription) == True
+    assert template.filtre_criteres(inscription) == True
     inscription.deplacement = ["tec"]
-    assert t.filtre_criteres(inscription) == True
+    assert template.filtre_criteres(inscription) == True
     inscription.deplacement = ["tec", "velo"]
-    assert t.filtre_criteres(inscription) == True
+    assert template.filtre_criteres(inscription) == True
 
-def test_animaux_domestiques(templates, inscription):
-    t = templates[0]
-    t.animaux_domestiques = None
-    assert t.filtre_criteres(inscription) == True
+def test_animaux_domestiques(template, inscription):
+    template.animaux_domestiques = None
+    assert template.filtre_criteres(inscription) == True
     inscription.animaux_domestiques = ["chat"]
-    assert t.filtre_criteres(inscription) == True
+    assert template.filtre_criteres(inscription) == True
 
-    t.animaux_domestiques = True
+    template.animaux_domestiques = True
     inscription.animaux_domestiques = None
-    assert t.filtre_criteres(inscription) == False
+    assert template.filtre_criteres(inscription) == False
     inscription.animaux_domestiques = ["chat"]
-    assert t.filtre_criteres(inscription) == True
+    assert template.filtre_criteres(inscription) == True
 
-    t.animaux_domestiques = False
+    template.animaux_domestiques = False
     inscription.animaux_domestiques = ["chat"]
-    assert t.filtre_criteres(inscription) == False
+    assert template.filtre_criteres(inscription) == False
     inscription.animaux_domestiques = None
-    assert t.filtre_criteres(inscription) == True
+    assert template.filtre_criteres(inscription) == True
 
-def test_deux_criteres(templates, inscription):
-    t = templates[0]
-    t.animaux_domestiques = True
-    t.deplacement = ['velo']
+def test_deux_criteres(template, inscription):
+    template.animaux_domestiques = True
+    template.deplacement = ['velo']
 
-    assert t.filtre_criteres(inscription) == False
+    assert template.filtre_criteres(inscription) == False
     inscription.animaux_domestiques = ["chat"]
-    assert t.filtre_criteres(inscription) == False
+    assert template.filtre_criteres(inscription) == False
     inscription.deplacement = ["velo"]
-    assert t.filtre_criteres(inscription) == True
+    assert template.filtre_criteres(inscription) == True
 
 
 def test_vraie_vie(templates, inscription, db_session):
@@ -242,34 +236,33 @@ def test_vraie_vie(templates, inscription, db_session):
 
     nls = list(Newsletter.export(type_='hebdomadaire', filter_already_sent=False))
     assert len(nls) == 1
-    assert nls[0].newsletter_hebdo_template.id == templates[-1].id
+    assert nls[0].newsletter_hebdo_template.id == templates[4].id
 
-def test_indicateurs(templates, inscription, db_session):
-    t = templates[0]
-    t.indicateurs = None
+def test_indicateurs(template, inscription, db_session):
+    template.indicateurs = None
     inscription.indicateurs = ["raep", "indice_atmo"]
-    assert t.filtre_criteres(inscription) == True
+    assert template.filtre_criteres(inscription) == True
 
-    t.indicateurs = []
-    assert t.filtre_criteres(inscription) == True
+    template.indicateurs = []
+    assert template.filtre_criteres(inscription) == True
 
-    t.indicateurs = inscription.indicateurs
-    assert t.filtre_criteres(inscription) == True
+    template.indicateurs = inscription.indicateurs
+    assert template.filtre_criteres(inscription) == True
 
     inscription.indicateurs = []
-    assert t.filtre_criteres(inscription) == False
+    assert template.filtre_criteres(inscription) == False
 
-    t.indicateurs = []
-    assert t.filtre_criteres(inscription) == True
+    template.indicateurs = []
+    assert template.filtre_criteres(inscription) == True
 
-    t.indicateurs = ["raep"]
+    template.indicateurs = ["raep"]
     inscription.indicateurs = ["indice_atmo"]
-    assert t.filtre_criteres(inscription) == False
+    assert template.filtre_criteres(inscription) == False
 
-    t.indicateurs = ["raep"]
+    template.indicateurs = ["raep"]
     inscription.indicateurs = ["indice_atmo", "raep"]
-    assert t.filtre_criteres(inscription) == True
+    assert template.filtre_criteres(inscription) == True
 
-    t.indicateurs = ["raep", "indice_atmo"]
+    template.indicateurs = ["raep", "indice_atmo"]
     inscription.indicateurs = ["indice_atmo"]
-    assert t.filtre_criteres(inscription) == True
+    assert template.filtre_criteres(inscription) == True

--- a/tests/test_newsletter_hedbo.py
+++ b/tests/test_newsletter_hedbo.py
@@ -326,7 +326,6 @@ def test_meme_ordre_population_recoupe(templates, inscription, db_session):
         if template.ordre >= 12:
             continue
         nl = Newsletter(newsletter_hebdo_template=template, inscription=inscription)
-        nl.date = date.today() - timedelta(days=1)
         db_session.add(NewsletterDB(nl))
     db_session.commit()
     inscription = Inscription.query.get(inscription.id)

--- a/tests/test_newsletter_hedbo.py
+++ b/tests/test_newsletter_hedbo.py
@@ -265,7 +265,44 @@ def test_indicateurs(template, inscription, db_session):
 
     template.indicateurs = ["raep", "indice_atmo"]
     inscription.indicateurs = ["indice_atmo"]
+    assert template.filtre_criteres(inscription) == False
+
+    template.indicateurs = ["raep", "indice_atmo"]
+    inscription.indicateurs = ["indice_atmo", "raep"]
     assert template.filtre_criteres(inscription) == True
+
+def test_indicateurs_exclus(template, inscription, db_session):
+    template.indicateurs_exclus = None
+    inscription.indicateurs = ["raep", "indice_atmo"]
+    assert template.filtre_criteres(inscription) == True
+
+    template.indicateurs_exclus = []
+    assert template.filtre_criteres(inscription) == True
+
+    template.indicateurs_exclus = inscription.indicateurs
+    assert template.filtre_criteres(inscription) == False
+
+    inscription.indicateurs = []
+    assert template.filtre_criteres(inscription) == True
+
+    template.indicateurs_exclus = []
+    assert template.filtre_criteres(inscription) == True
+
+    template.indicateurs_exclus = ["raep"]
+    inscription.indicateurs = ["indice_atmo"]
+    assert template.filtre_criteres(inscription) == True
+
+    template.indicateurs_exclus = ["raep"]
+    inscription.indicateurs = ["indice_atmo", "raep"]
+    assert template.filtre_criteres(inscription) == False
+
+    template.indicateurs_exclus = ["raep", "indice_atmo"]
+    inscription.indicateurs = ["indice_atmo"]
+    assert template.filtre_criteres(inscription) == False
+
+    template.indicateurs_exclus = ["raep", "indice_atmo"]
+    inscription.indicateurs = ["indice_atmo", "raep"]
+    assert template.filtre_criteres(inscription) == False
 
 def test_meme_ordre(templates, inscription, db_session):
     for template in templates:


### PR DESCRIPTION
Deux changements dans cette PR : 
1) Les `NewsletterHebdoTemplate.ordre` peuvent avoir la même valeur, ce qui permet de faire des _segments_
2) Les indicateurs présents dans `NewsletterHebdoTemplate.indicateurs` doivent être tous présents dans `inscription.indicateurs`
Aucun des indicateurs présents dans `NewsletterHebdoTemplate.indicateurs_exclus` doit être présent dans `inscription.indicateurs`