### PR TITLE
Correctif pour filtrage de l'activité physique sur les newsletters hebdos

### DIFF
--- a/ecosante/newsletter/models.py
+++ b/ecosante/newsletter/models.py
@@ -69,6 +69,8 @@ class NewsletterHebdoTemplate(db.Model):
         for nom_critere in ['chauffage', 'activites', 'deplacement']:
             critere = getattr(self, nom_critere)
             if isinstance(critere, list) and len(critere) > 0:
+                if nom_critere == 'activites':
+                    critere = list(map(lambda x: x.replace('activite_physique', 'sport'), critere))
                 inscription_critere = getattr(inscription, nom_critere)
                 if not isinstance(inscription_critere, list):
                     return False

--- a/tests/test_newsletter_hedbo.py
+++ b/tests/test_newsletter_hedbo.py
@@ -139,7 +139,25 @@ def test_activites(template, inscription):
     inscription.activites = ["menage"]
     assert template.filtre_criteres(inscription) == True
 
-    template.activites = ["menage", "bricolage"]
+    template.activites = ["bricolage"]
+    inscription.activites = None
+    assert template.filtre_criteres(inscription) == False
+    inscription.activites = ["bricolage"]
+    assert template.filtre_criteres(inscription) == True
+
+    template.activites = ["jardinage"]
+    inscription.activites = None
+    assert template.filtre_criteres(inscription) == False
+    inscription.activites = ["jardinage"]
+    assert template.filtre_criteres(inscription) == True
+
+    template.activites = ["activite_physique"]
+    inscription.activites = None
+    assert template.filtre_criteres(inscription) == False
+    inscription.activites = ["sport"]
+    assert template.filtre_criteres(inscription) == True
+
+    template.activites = ["menage", "bricolage", "activite_physique"]
     inscription.activites = None
     assert template.filtre_criteres(inscription) == False
     inscription.activites = ["menage"]
@@ -147,6 +165,8 @@ def test_activites(template, inscription):
     inscription.activites = ["bricolage"]
     assert template.filtre_criteres(inscription) == True
     inscription.activites = ["bricolage", "menage"]
+    assert template.filtre_criteres(inscription) == True
+    inscription.activites = ["bricolage", "menage", "sport"]
     assert template.filtre_criteres(inscription) == True
 
 def test_enfants(template, inscription):


### PR DESCRIPTION
"activite_physique" employé pour les newsletters hebdos et recommandations alors que "sport" est employé lors des inscriptions