### PR TITLE
Essai de fix d’absence de short_id

### DIFF
--- a/ecosante/newsletter/tasks/import_in_sb.py
+++ b/ecosante/newsletter/tasks/import_in_sb.py
@@ -122,7 +122,7 @@ def import_in_db(task, now, type_='quotidien', force_send=False, test=False, mai
             }
         )
     row2dict = lambda r: {
-        c.name: getattr(r, c.name) for c in r.__table__.columns if c.name != "id"
+        c.name: getattr(r, c.name) for c in r.__table__.columns if not c.name in ["id", "short_id"]
     }
     to_add = []
     for nl in (newsletters or Newsletter.export(type_=type_, force_send=force_send, filter_already_sent=filter_already_sent)):


### PR DESCRIPTION
Dans la base de données certaines newsletters n’ont pas de `short_id`.
Je n’ai pas réussi à trouver de point commun entre les nl n’ayant pas de
short_id.

Le short_id est généré par postgresql, mon instint me dit que peut être
que l’on envoi le short_id en python et que psql se dit qu’il n’a pas
besoin de le setter, je tente donc de l’enlever de ce qu’on envoie à
postgresql.