### PR TITLE
Nouvelle façon pour s’authentifier à l’administration

### DIFF
--- a/ecosante/extensions.py
+++ b/ecosante/extensions.py
@@ -8,7 +8,7 @@ from markdown_link_attr_modifier import LinkAttrModifierExtension
 import sib_api_v3_sdk
 from flask_cors import CORS
 from markdown import Markdown
-from ecosante.utils.authenticator import APIAuthenticator
+from ecosante.utils.authenticator import APIAuthenticator, AdminAuthenticator
 
 db = SQLAlchemy()
 migrate = Migrate()
@@ -22,5 +22,6 @@ markdown = Markdown(
 )
 cache = Cache()
 authenticator = APIAuthenticator()
+admin_authenticator = AdminAuthenticator()
 
 import ecosante.utils.rollup

--- a/ecosante/extensions.py
+++ b/ecosante/extensions.py
@@ -8,7 +8,7 @@ from markdown_link_attr_modifier import LinkAttrModifierExtension
 import sib_api_v3_sdk
 from flask_cors import CORS
 from markdown import Markdown
-from ecosante.utils.authenticator import TempAuthenticator
+from ecosante.utils.authenticator import APIAuthenticator
 
 db = SQLAlchemy()
 migrate = Migrate()
@@ -21,6 +21,6 @@ markdown = Markdown(
     extensions=[LinkAttrModifierExtension(new_tab='on')]
 )
 cache = Cache()
-authenticator = TempAuthenticator()
+authenticator = APIAuthenticator()
 
 import ecosante.utils.rollup

--- a/ecosante/newsletter/blueprint.py
+++ b/ecosante/newsletter/blueprint.py
@@ -21,9 +21,8 @@ from sqlalchemy import func
 from ecosante.inscription.models import Inscription
 from ecosante.recommandations.models import Recommandation
 
-from ecosante.utils.decorators import admin_capability_url
 from ecosante.utils import Blueprint
-from ecosante.extensions import db, sib
+from ecosante.extensions import db, sib, admin_authenticator
 from .forms import FormTemplateAdd, FormTemplateEdit
 from .models import Newsletter, NewsletterDB, NewsletterHebdoTemplate
 from .tasks.import_in_sb import create_campaign, import_, send
@@ -50,9 +49,8 @@ def avis(short_id):
         "appliquee": nl.appliquee
     }
 
-@bp.route('<secret_slug>/avis/liste')
 @bp.route('/avis/liste')
-@admin_capability_url
+@admin_authenticator.route
 def liste_avis():
     newsletters = NewsletterDB.query\
         .filter(NewsletterDB.avis.isnot(None))\
@@ -61,9 +59,8 @@ def liste_avis():
     return render_template('liste_avis.html', newsletters=newsletters)
 
 
-@bp.route('<secret_slug>/avis/csv')
 @bp.route('/avis/csv')
-@admin_capability_url
+@admin_authenticator.route
 def export_avis():
     return Response(
         stream_with_context(
@@ -75,9 +72,8 @@ def export_avis():
         }
     )
 
-@bp.route('<secret_slug>/test', methods=['GET', 'POST'])
 @bp.route('/test', methods=['GET', 'POST'])
-@admin_capability_url
+@admin_authenticator.route
 def test():
     if request.method == "GET":
         return render_template("test.html")
@@ -132,9 +128,8 @@ def test():
 
     return render_template("test_ok.html", nb_mails=nb_mails, nb_notifications=nb_notifications, nb_notifications_sent=nb_notifications_sent)
 
-@bp.route('<secret_slug>/newsletter_hebdo_templates', methods=['GET', 'POST'])
 @bp.route('/newsletter_hebdo_templates', methods=['GET', 'POST'])
-@admin_capability_url
+@admin_authenticator.route
 def newsletter_hebdo():
     templates_db = NewsletterHebdoTemplate.query.order_by(NewsletterHebdoTemplate.ordre).all()
     templates = []
@@ -151,11 +146,9 @@ def newsletter_hebdo():
     return render_template("newsletter_hebdo_templates.html", templates=templates)
 
 
-@bp.route('<secret_slug>/newsletter_hebdo/_add', methods=['GET', 'POST'])
 @bp.route('/newsletter_hebdo/_add', methods=['GET', 'POST'])
-@bp.route('<secret_slug>/newsletter_hebdo/<int:id_>/_edit', methods=['GET', 'POST'])
 @bp.route('/newsletter_hebdo/<int:id_>/_edit', methods=['GET', 'POST'])
-@admin_capability_url
+@admin_authenticator.route
 def newsletter_hebdo_form(id_=None):
     form_cls = FormTemplateEdit if id_ else FormTemplateAdd
     form = form_cls(obj=NewsletterHebdoTemplate.query.get(id_))

--- a/ecosante/newsletter/templates/liste_avis.html
+++ b/ecosante/newsletter/templates/liste_avis.html
@@ -1,4 +1,4 @@
-{% extends 'base.html' %}
+{% extends 'base_admin.html' %}
 
 {% block content %}
 <section class="section">

--- a/ecosante/newsletter/templates/newsletter_hebdo_form.html
+++ b/ecosante/newsletter/templates/newsletter_hebdo_form.html
@@ -1,4 +1,4 @@
-{% extends "base_form.html" %}
+{% extends "base_admin_form.html" %}
 
 {% block block_form %}
 

--- a/ecosante/newsletter/templates/newsletter_hebdo_templates.html
+++ b/ecosante/newsletter/templates/newsletter_hebdo_templates.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}
+{% extends "base_admin.html" %}
 
 {% block content %}
   <div class="section">

--- a/ecosante/newsletter/templates/test_ok.html
+++ b/ecosante/newsletter/templates/test_ok.html
@@ -1,5 +1,5 @@
 
-{% extends "base.html" %}
+{% extends "base_admin.html" %}
 {% block content %}
 <div class="section">
 	<div class="container">

--- a/ecosante/pages/blueprint.py
+++ b/ecosante/pages/blueprint.py
@@ -29,7 +29,7 @@ def redirection_index():
     return redirect("https://recosante.beta.gouv.fr/", code=301)
 
 
-@bp.route('/admin')
+@bp.route('/admin', strict_slashes=False)
 @admin_authenticator.route
 def admin():
     count_avis_hier = NewsletterDB.query\
@@ -44,7 +44,7 @@ def admin():
         .count()
     return render_template("admin.html", count_avis_hier=count_avis_hier, count_avis_aujourdhui=count_avis_aujourdhui)
 
-@bp.route('/admin_login', methods=['GET', 'POST'])
+@bp.route('/admin_login/', methods=['GET', 'POST'], strict_slashes=False)
 def admin_login():
     class AdminForm(BaseForm):
         email = EmailField()

--- a/ecosante/pages/templates/admin_login.html
+++ b/ecosante/pages/templates/admin_login.html
@@ -1,0 +1,19 @@
+{% extends 'base_form.html'%}
+{% block pre_form %}
+
+<div class="hero">
+      <div class="hero__container" role="banner">
+        <h1>LOGIN ADMIN</h1>
+      </div>
+</div>
+{% endblock pre_form %}
+
+{% block block_form %}
+<form method="POST" novalidate>
+    {{ form.hidden_tag() }}
+    {{ render_field(form.email) }}
+    <div class="form__group">
+        <button class="button" type="submit" id="submit">Authentification</button>
+    </div>
+</form>
+{% endblock block_form %}

--- a/ecosante/pages/templates/admin_login_done.html
+++ b/ecosante/pages/templates/admin_login_done.html
@@ -1,0 +1,9 @@
+{% extends 'base.html'%}
+{% block content %}
+<section class="section section-grey">
+    <div class="container">
+        <h1>Email envoyé</h1>
+        <p>Un email de connexion vous a été envoyé à l’adresse indiquée</p>
+    </div>
+</section>
+{% endblock %}

--- a/ecosante/recommandations/blueprint.py
+++ b/ecosante/recommandations/blueprint.py
@@ -11,13 +11,13 @@ from flask import (
     flash,
     stream_with_context
 )
+from ecosante.extensions import admin_authenticator
 from flask.wrappers import Response
 from datetime import datetime
 from itertools import chain
 from .models import Recommandation, db
 from ecosante.newsletter.models import NewsletterDB
 from .forms import FormAdd, FormEdit, FormSearch
-from ecosante.utils.decorators import admin_capability_url
 from ecosante.utils import Blueprint
 from ecosante.utils.funcs import generate_line
 from sqlalchemy import or_, func
@@ -37,9 +37,8 @@ def list_recommandations():
 def rendu_markdown():
     return Recommandation.sanitizer(request.form.get('to_render'))
 
-@bp.route('<secret_slug>/add', methods=['GET', 'POST'])
 @bp.route('add', methods=['GET', 'POST'])
-@admin_capability_url
+@admin_authenticator.route
 def add():
     form = FormAdd()
     if request.method == "POST":
@@ -55,9 +54,8 @@ def add():
         action="Ajouter"
     )
 
-@bp.route('<secret_slug>/edit/<id>', methods=['GET', 'POST'])
 @bp.route('edit/<id>', methods=['GET', 'POST'])
-@admin_capability_url
+@admin_authenticator.route
 def edit(id):
     recommandation = db.session.query(Recommandation).get(id)
     if not recommandation:
@@ -75,9 +73,8 @@ def edit(id):
         recommandation=recommandation
     )
 
-@bp.route('<secret_slug>/remove/<id>', methods=["GET", "POST"])
 @bp.route('remove/<id>', methods=["GET", "POST"])
-@admin_capability_url
+@admin_authenticator.route
 def remove(id):
     recommandation = Recommandation.query.get(id)
     if request.method == "POST":
@@ -121,9 +118,8 @@ def make_query(form):
     else:
         return query.order_by(Recommandation.id)
 
-@bp.route('<secret_slug>/', methods=["GET", "POST"])
 @bp.route('/', methods=["GET", "POST"])
-@admin_capability_url
+@admin_authenticator.route
 def list_():
     form = FormSearch(request.args)
     query = make_query(form)
@@ -134,9 +130,8 @@ def list_():
         form=form,
     )
 
-@bp.route('<secret_slug>/csv', methods=["GET", "POST"])
 @bp.route('/csv', methods=["GET", "POST"])
-@admin_capability_url
+@admin_authenticator.route
 def csv():
     form = FormSearch(request.args)
     query = make_query(form)
@@ -157,9 +152,8 @@ def csv():
         }
     )
 
-@bp.route('/<secret_slug>/<id>/details')
 @bp.route('/<id>/details')
-@admin_capability_url
+@admin_authenticator.route
 def details(id):
     recommandation = Recommandation.query.get(id)
     if not recommandation:

--- a/ecosante/recommandations/templates/details.html
+++ b/ecosante/recommandations/templates/details.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}
+{% extends "base_admin.html" %}
 
 {% block content %}
 

--- a/ecosante/recommandations/templates/edit.html
+++ b/ecosante/recommandations/templates/edit.html
@@ -1,4 +1,4 @@
-{% extends "base_form.html" %}
+{% extends "base_admin_form.html" %}
 
 {% block pre_form %}
 

--- a/ecosante/recommandations/templates/list.html
+++ b/ecosante/recommandations/templates/list.html
@@ -1,4 +1,4 @@
-{% extends 'base_form.html'%}
+{% extends 'base_admin_form.html'%}
 
 {% block block_form %}
 {% scss "recommandations/css/list.scss" %}

--- a/ecosante/recommandations/templates/remove.html
+++ b/ecosante/recommandations/templates/remove.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}
+{% extends "base_admin.html" %}
 
 {% block content %}
 

--- a/ecosante/tasks/__init__.py
+++ b/ecosante/tasks/__init__.py
@@ -2,6 +2,8 @@ from celery.schedules import crontab
 from ecosante.extensions import celery
 from flask import current_app
 from .import_from_production import import_from_production
+from .send_admin_link import send_admin_link
+from .inscriptions_patients import inscription_patients_task
 
 @celery.on_after_configure.connect
 def setup_periodic_tasks(sender, **kwargs):

--- a/ecosante/tasks/send_admin_link.py
+++ b/ecosante/tasks/send_admin_link.py
@@ -1,0 +1,43 @@
+import sib_api_v3_sdk
+from ecosante.extensions import celery, sib, admin_authenticator
+from ecosante.inscription.models import Inscription
+import os
+from sib_api_v3_sdk.rest import ApiException
+from time import sleep
+from flask import current_app, url_for
+
+@celery.task()
+def send_admin_link(email):
+    if email not in admin_authenticator.admin_emails:
+        return
+
+    token = admin_authenticator.make_token(email)
+    email_api = sib_api_v3_sdk.TransactionalEmailsApi(sib)
+    try:
+        email_api.send_transac_email(
+            sib_api_v3_sdk.SendSmtpEmail(
+                subject='Lien connexion recosanté',
+                sender=sib_api_v3_sdk.SendSmtpEmailSender(
+                    name= "Recosanté",
+                    email= "hi@recosante.beta.gouv.fr"
+                ),
+                to=[sib_api_v3_sdk.SendSmtpEmailTo(email=email)],
+                reply_to=sib_api_v3_sdk.SendSmtpEmailReplyTo(
+                    name="Recosanté",
+                    email="hi@recosante.beta.gouv.fr"
+                ),
+                html_content=f"""
+                Bonjour,
+                Voici votre <a href="{url_for("pages.authenticate", _external=True, token=token)}">lien pour aller sur l’administration</a>
+                Bonne journée
+                """
+            )
+        )
+    except ApiException as e:
+        current_app.logger.error(
+            f"Error: {e}"
+        )
+        raise e
+    current_app.logger.info(
+        f"Mail d’authentication à l’administration envoyé à {email}"
+    )

--- a/ecosante/tasks/send_admin_link.py
+++ b/ecosante/tasks/send_admin_link.py
@@ -13,6 +13,7 @@ def send_admin_link(email):
 
     token = admin_authenticator.make_token(email)
     email_api = sib_api_v3_sdk.TransactionalEmailsApi(sib)
+    authentication_link = url_for("pages.authenticate", _external=True, token=token)
     try:
         email_api.send_transac_email(
             sib_api_v3_sdk.SendSmtpEmail(
@@ -28,7 +29,12 @@ def send_admin_link(email):
                 ),
                 html_content=f"""
                 Bonjour,
-                Voici votre <a href="{url_for("pages.authenticate", _external=True, token=token)}">lien pour aller sur l’administration</a>
+                Voici votre <a href="{ authentication_link }">lien pour aller sur l’administration</a>
+                Bonne journée
+                """,
+                text_content=f"""
+                Bonjour,
+                Voici votre lien pour aller sur l’administration : { authentication_link }
                 Bonne journée
                 """
             )

--- a/ecosante/templates/base.html
+++ b/ecosante/templates/base.html
@@ -55,6 +55,8 @@
     {% endfor %}
   {% endif %}
 {% endwith %}
+{% block precontent %}
+{% endblock precontent %}
 {% block content %}
 {% endblock content %}
 

--- a/ecosante/templates/base_admin.html
+++ b/ecosante/templates/base_admin.html
@@ -1,0 +1,5 @@
+{% extends 'base.html' %}
+
+{% block precontent %}
+    <a href="/admin/">Revenir à l’Admin</a>
+{% endblock %}

--- a/ecosante/templates/base_admin_form.html
+++ b/ecosante/templates/base_admin_form.html
@@ -1,4 +1,4 @@
-{% extends 'base.html' %}
+{% extends 'base_form.html' %}
 
 {% block precontent %}
     <a href="{{ url_for("pages.admin") }}">Revenir à l’Admin</a>

--- a/ecosante/users/blueprint.py
+++ b/ecosante/users/blueprint.py
@@ -1,6 +1,5 @@
 from flask.globals import request
-from ecosante.extensions import rebar, db
-from ecosante.utils.decorators import admin_capability_url
+from ecosante.extensions import rebar, db, admin_authenticator
 from .schemas import RequestPOST, Response, RequestPOSTID, RequestUpdateProfile
 from ecosante.inscription.models import Inscription
 from ecosante.extensions import celery, authenticator
@@ -12,7 +11,7 @@ registry = rebar.create_handler_registry('/users/')
     hidden=True,
     response_body_schema={200:Response(many=True)}
 )
-@admin_capability_url
+@admin_authenticator.route
 def search_users():
     mail = request.args.get('mail')
     return Inscription.active_query()\

--- a/ecosante/utils/authenticator.py
+++ b/ecosante/utils/authenticator.py
@@ -1,12 +1,13 @@
+from lib2to3.pytree import Base
 from time import time
-from flask import current_app, request
+from flask import current_app, request, session, redirect, url_for, abort
 from flask_rebar.authenticators.base import Authenticator
 from flask_rebar import errors, messages
 from jose import jwt
 from hmac import compare_digest
 import os
 
-class TempAuthenticator(Authenticator):
+class BaseAuthenticator:
     def __init__(self) -> None:
         self.secret = os.getenv('AUTHENTICATOR_SECRET')
         if self.secret is None:
@@ -14,7 +15,19 @@ class TempAuthenticator(Authenticator):
 
     def decode_token(self, encoded_token):
         return jwt.decode(encoded_token, self.secret, options={"require_exp": True, "leeway": 0})
+    
+    def make_token(self, uid, time_= None):
+        time_ = time_ or time() + current_app.config['TEMP_AUTHENTICATOR_EXP_TIME']
+        return jwt.encode(
+            {
+                'exp': time_,
+                'uid': uid
+            },
+            self.secret,
+            'HS256'
+        )
 
+class APIAuthenticator(Authenticator, BaseAuthenticator):
     def authenticate(self):
         encoded_token = request.args.get('token')
         if not encoded_token:
@@ -29,14 +42,28 @@ class TempAuthenticator(Authenticator):
 
         if not compare_digest(view_uid, decoded_token.get('uid')):
             raise errors.Unauthorized(messages.invalid_auth_token)
+
+class AdminAuthenticator(BaseAuthenticator):
+    def __init__(self) -> None:
+        super().__init__()
+        if (admin_str := os.getenv('ADMINS_LIST')) != None:
+            self.admin_emails = [v for v in admin_str.split(' ') if v]
+            if len(self.admin_emails) < 1:
+                raise Exception("ADMINS_LIST can not be empty")
+        else:
+            raise Exception("ADMINS_LIST var env is required")
+        
+
+class AdminAuthenticatorDecorator(AdminAuthenticator):
+    def __init__(self, f) -> None:
+        super().__init__()
+        self.f = f
     
-    def make_token(self, uid, time_= None):
-        time_ = time_ or time() + current_app.config['TEMP_AUTHENTICATOR_EXP_TIME']
-        return jwt.encode(
-            {
-                'exp': time_,
-                'uid': uid
-            },
-            self.secret,
-            'HS256'
-        )
+    def __call__(self):
+        admin_email = session.get('admin_email')
+        if admin_email is None:
+            return redirect(url_for('pages.login'))
+        elif admin_email not in self.admin_emails:
+            abort(401)
+        else:
+            return self.f()

--- a/ecosante/utils/decorators.py
+++ b/ecosante/utils/decorators.py
@@ -1,35 +1,22 @@
-from functools import (
-    wraps,
-    partial
-)
+from functools import wraps
 from flask import (
     abort,
     current_app,
-    redirect,
     request,
-    url_for,
     session
 )
 import os
 
-def capability_url(env_key, redirect_to_slash, f):
+def webhook_capability_url(f):
     @wraps(f)
-    def decorated_function(*args, **kwargs):
-        capability_token = os.getenv(env_key)
-        if capability_token is None:
+    def wrapper(*args, **kwargs):
+        env_key = 'CAPABILITY_WEBHOOK_TOKEN'
+        if (capability_token := os.getenv(env_key)) is None:
             current_app.logger.error(f"La variable d'environnement {env_key} n'existe pas")
             abort(500)
-        if 'secret_slug' in kwargs and redirect_to_slash:
-            session['secret_slug'] = kwargs.pop('secret_slug')
-            return redirect(
-                url_for(request.endpoint, **kwargs)
-            )
         secret_slug = session.get('secret_slug') or kwargs.get('secret_slug')
         if secret_slug != capability_token:
             current_app.logger.error(f"L'url \"{request.url}\" a été accédée avec un mauvais token")
             abort(401)
         return f(*args, **kwargs)
-    return decorated_function
-
-admin_capability_url = partial(capability_url, 'CAPABILITY_ADMIN_TOKEN', True)
-webhook_capability_url = partial(capability_url, 'CAPABILITY_WEBHOOK_TOKEN', False)
+    return wrapper

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -1,7 +1,10 @@
-from ecosante.utils.authenticator import TempAuthenticator
+from ecosante.utils.authenticator import APIAuthenticator, AdminAuthenticatorDecorator
 from time import time
 from jose import jwt
-
+import os
+import pytest
+from flask import session
+from werkzeug.exceptions import HTTPException
 
 def test_no_token(client):
     response = client.get('/users/uid1')
@@ -14,21 +17,21 @@ def test_bad_token(client):
     assert response.json['message'] == 'Invalid authentication.'
 
 def test_expired_token(client):
-    authenticator = TempAuthenticator()
+    authenticator = APIAuthenticator()
     token = authenticator.make_token('monuid', time() - 60)
     response = client.get(f'/users/uid1?token={token}')
     assert response.status_code == 401
     assert response.json['message'] == 'Invalid authentication.'
 
 def test_no_expired_token(client):
-    authenticator = TempAuthenticator()
+    authenticator = APIAuthenticator()
     token = jwt.encode({'uid': 'monuid'}, authenticator.secret, 'HS256')
     response = client.get(f'/users/uid1?token={token}')
     assert response.status_code == 401
     assert response.json['message'] == 'Invalid authentication.'
 
 def test_mauvais_uid(client):
-    authenticator = TempAuthenticator()
+    authenticator = APIAuthenticator()
     token = authenticator.make_token('monuid')
     response = client.get(f'/users/uid1?token={token}')
     assert response.status_code == 401
@@ -37,7 +40,68 @@ def test_mauvais_uid(client):
 def test_bon_uid(client, inscription, db_session):
     db_session.add(inscription)
     db_session.commit()
-    authenticator = TempAuthenticator()
+    authenticator = APIAuthenticator()
     token = authenticator.make_token(inscription.uid)
     response = client.get(f'/users/{inscription.uid}?token={token}')
     assert response.status_code == 200
+
+def test_no_admins_list_env():
+    os.unsetenv('ADMINS_LIST')
+    with pytest.raises(Exception) as exc_info:
+        @AdminAuthenticatorDecorator
+        def f():
+            pass
+    assert str(exc_info.value) == "ADMINS_LIST var env is required"
+
+def test_empty_admins_list_env():
+    os.environ['ADMINS_LIST'] = ""
+    with pytest.raises(Exception) as exc_info:
+        @AdminAuthenticatorDecorator
+        def f():
+            pass
+    assert str(exc_info.value) == "ADMINS_LIST can not be empty"
+
+
+def test_one_email_in_admins_list_env():
+    os.environ['ADMINS_LIST'] = "test@test.com"
+    admin_decorator = AdminAuthenticatorDecorator(None)
+    assert admin_decorator.admin_emails == ["test@test.com"]
+
+
+def test_two_emails_in_admins_list_env():
+    os.environ['ADMINS_LIST'] = "test@test.com test2@pouet.com"
+    admin_decorator = AdminAuthenticatorDecorator(None)
+    assert admin_decorator.admin_emails == ["test@test.com", "test2@pouet.com"]
+
+def test_no_admin_email_in_session(app):
+    os.environ['ADMINS_LIST'] = 'test@test.com'
+    with app.test_request_context('/'):
+        @AdminAuthenticatorDecorator
+        def f():
+            pass
+        
+        response = f()
+    assert response.location == '/login'
+
+def test_unknown_email_in_session(app):
+    os.environ['ADMINS_LIST'] = 'test@test.com'
+    with app.test_request_context('/'):
+        session['admin_email'] = 'unknown@email.com'
+        @AdminAuthenticatorDecorator
+        def f():
+            pass
+        with pytest.raises(HTTPException) as exc_info:
+            f()
+    assert exc_info.value.code == 401
+
+def test_authorized_email_in_session(app):
+    os.environ['ADMINS_LIST'] = 'test@test.com second@autredomaine.com'
+    with app.test_request_context('/'):
+        session['admin_email'] = 'test@test.com'
+        @AdminAuthenticatorDecorator
+        def f():
+            return session.get('admin_email')
+        assert f() == 'test@test.com'
+
+        session['admin_email'] = 'second@autredomaine.com'
+        assert f() == 'second@autredomaine.com'

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -85,7 +85,7 @@ def test_no_admin_email_in_session(app):
             pass
         
         response = f()
-    assert response.location == '/admin_login'
+    assert response.location == '/admin_login/'
 
 def test_unknown_email_in_session(app):
     os.environ['ADMINS_LIST'] = 'test@test.com'

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -4,7 +4,7 @@ from ecosante.users.schemas import User
 from ecosante.extensions import authenticator
 import json
 
-from ecosante.utils.authenticator import TempAuthenticator
+from ecosante.utils.authenticator import APIAuthenticator
 
 def test_no_mail(client):
     data = {
@@ -126,7 +126,7 @@ def test_get_user(commune_commited, client):
     uid = response.json["uid"]
     response = client.get(f'/users/{uid}')
     assert response.status_code == 401
-    authenticator = TempAuthenticator()
+    authenticator = APIAuthenticator()
     response = client.get(f'/users/{uid}?token={authenticator.make_token(uid)}')
     assert response.status_code == 200
     assert response.json['uid'] == uid
@@ -158,7 +158,7 @@ def test_update_user_bad_uid(commune_commited, client):
             "code": "53130"
         }
     }
-    authenticator = TempAuthenticator()
+    authenticator = APIAuthenticator()
     response = client.post('/users/', json=data)
     assert response.status_code == 201
     uid = response.json['uid'] + 'bad'
@@ -179,7 +179,7 @@ def test_update_user(commune_commited, client):
     assert inscription is not None
     assert inscription.animaux_domestiques == None
 
-    authenticator = TempAuthenticator()
+    authenticator = APIAuthenticator()
     uid = response.json['uid']
     data['animaux_domestiques'] = ['chat']
     response = client.post(f'/users/{uid}', json=data)
@@ -240,6 +240,6 @@ def test_update_user_with_existing_email(commune_commited, client):
     data['mail'] = 'lebo@tonvelo.com'
     response = client.post(f'/users/{uid}', json=data)
     assert response.status_code == 401
-    authenticator = TempAuthenticator()
+    authenticator = APIAuthenticator()
     response = client.post(f'/users/{uid}?token={authenticator.make_token(uid)}', json=data)
     assert response.status_code == 409


### PR DESCRIPTION
Pour s’authentifier à l’administration il faut maintenant faire une demande de lien de connexion.

Les emails des administrateurs sont définis dans la variable d’environnement : `ADMINS_LIST` les emails y sont séparés par des espaces.

Aussi il a été ajouté un lien de retour à l’index de l’administration sur les pages d’administrations.
Et on en a profité pour nettoyer un peu de code.

Pour que l’envoi de mail fonctionne il faut qu‘un worker celery soit en fonctionnement en même temps que le serveur web.
Vous pouvez en lancer un avec : `celery --app ecosante.celery_worker.celery worker -E`