### PR TITLE
Ajout de la fonction gen-short-id à la création des tests

### DIFF
--- a/migrations/data/generate-random-short-id.sql
+++ b/migrations/data/generate-random-short-id.sql
@@ -1,0 +1,54 @@
+CREATE OR REPLACE FUNCTION get_random_string(
+        IN string_length integer,
+        IN possible_chars TEXT DEFAULT '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz'
+    ) RETURNS text
+    LANGUAGE plpgsql
+    AS $$
+DECLARE
+    output TEXT = '';
+    i INT4;
+    pos INT4;
+BEGIN
+    FOR i IN 1..string_length LOOP
+        pos := 1 + cast( random() * ( length(possible_chars) - 1) as INT4 );
+        output := output || substr(possible_chars, pos, 1);
+    END LOOP;
+    RETURN output;
+END;
+$$;
+
+create or replace function generate_random_id(
+    IN table_schema   TEXT,
+    IN table_name     TEXT,
+    IN column_name    TEXT,
+    IN string_length  INTEGER,
+    IN possible_chars TEXT DEFAULT '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz'
+) returns text
+    LANGUAGE plpgsql
+    AS $$
+DECLARE
+    v_random_id   text;
+    v_temp        text;
+    v_length      int4   :=  string_length;
+    v_sql         text;
+    v_advisory_1  int4 := hashtext( format('%I:%I:%I', table_schema, table_name, column_name) );
+    v_advisory_2  int4;
+    v_advisory_ok bool;
+BEGIN
+    v_sql := format( 'SELECT %I FROM %I.%I WHERE %I = $1', column_name, table_schema, table_name, column_name );
+    LOOP
+        v_random_id := get_random_string( v_length, possible_chars );
+        v_advisory_2 := hashtext( v_random_id );
+        v_advisory_ok := pg_try_advisory_xact_lock( v_advisory_1, v_advisory_2 );
+        IF v_advisory_ok THEN
+            EXECUTE v_sql INTO v_temp USING v_random_id;
+            exit when v_temp is null;
+        END IF;
+        v_length := v_length + 1;
+    END LOOP;
+    return v_random_id;
+END;
+$$
+STRICT
+SET search_path TO public
+;

--- a/migrations/versions/ec7ca2436d87_ajout_fonction_generate_random_id.py
+++ b/migrations/versions/ec7ca2436d87_ajout_fonction_generate_random_id.py
@@ -8,6 +8,7 @@ Create Date: 2020-11-13 10:35:45.913959
 from alembic import op
 import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql
+from sqlalchemy import text
 
 # revision identifiers, used by Alembic.
 revision = 'ec7ca2436d87'
@@ -17,62 +18,9 @@ depends_on = None
 
 
 def upgrade():
-    op.execute("""
-CREATE OR REPLACE FUNCTION get_random_string(
-        IN string_length integer,
-        IN possible_chars TEXT DEFAULT '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz'
-    ) RETURNS text
-    LANGUAGE plpgsql
-    AS $$
-DECLARE
-    output TEXT = '';
-    i INT4;
-    pos INT4;
-BEGIN
-    FOR i IN 1..string_length LOOP
-        pos := 1 + cast( random() * ( length(possible_chars) - 1) as INT4 );
-        output := output || substr(possible_chars, pos, 1);
-    END LOOP;
-    RETURN output;
-END;
-$$;
-
-create or replace function generate_random_id(
-    IN table_schema   TEXT,
-    IN table_name     TEXT,
-    IN column_name    TEXT,
-    IN string_length  INTEGER,
-    IN possible_chars TEXT DEFAULT '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz'
-) returns text
-    LANGUAGE plpgsql
-    AS $$
-DECLARE
-    v_random_id   text;
-    v_temp        text;
-    v_length      int4   :=  string_length;
-    v_sql         text;
-    v_advisory_1  int4 := hashtext( format('%I:%I:%I', table_schema, table_name, column_name) );
-    v_advisory_2  int4;
-    v_advisory_ok bool;
-BEGIN
-    v_sql := format( 'SELECT %I FROM %I.%I WHERE %I = $1', column_name, table_schema, table_name, column_name );
-    LOOP
-        v_random_id := get_random_string( v_length, possible_chars );
-        v_advisory_2 := hashtext( v_random_id );
-        v_advisory_ok := pg_try_advisory_xact_lock( v_advisory_1, v_advisory_2 );
-        IF v_advisory_ok THEN
-            EXECUTE v_sql INTO v_temp USING v_random_id;
-            exit when v_temp is null;
-        END IF;
-        v_length := v_length + 1;
-    END LOOP;
-    return v_random_id;
-END;
-$$
-STRICT
-SET search_path TO public
-;
-    """)
+    with open("migrations/data/generate-random-short-id.sql") as f:
+        query = text(f.read())
+        op.execute(query)
 
 
 def downgrade():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 from datetime import date, datetime, timedelta
+from unittest import TextTestResult
 from indice_pollution.history.models import zone
 from indice_pollution.history.models.commune import Commune
 from indice_pollution.history.models.indice_atmo import IndiceATMO
@@ -16,6 +17,7 @@ from ecosante.newsletter.models import NewsletterHebdoTemplate
 from ecosante.inscription.models import Inscription, WebpushSubscriptionInfo
 from ecosante.recommandations.models import Recommandation
 from .utils import published_recommandation
+from sqlalchemy import text
 
 # Retrieve a database connection string from the shell environment
 try:
@@ -49,6 +51,9 @@ def app(request):
     with app.app_context():
         db = app.extensions['sqlalchemy'].db
         db.engine.execute('DROP TABLE IF EXISTS alembic_version;')
+        with open("migrations/data/generate-random-short-id.sql") as f:
+            query = text(f.read())
+            db.engine.execute(query)
         db.metadata.bind = db.engine
         db.metadata.create_all()
         with cf.ProcessPoolExecutor() as pool:


### PR DESCRIPTION
Pour pouvoir démarrer d’une base vierge