### PR TITLE
Ajout d'un swagger_type au schema des recommandations

### DIFF
--- a/ecosante/api/schemas/indice.py
+++ b/ecosante/api/schemas/indice.py
@@ -16,13 +16,13 @@ class IndiceDetailsSchema(Schema):
 
 class AdviceSchema(Schema):
     main = fields.Function(
-        lambda recommandation, context: recommandation.format(context.get('commune'))
+        lambda recommandation, context: recommandation.format(context.get('commune')), swagger_type="string"
     )
     details = fields.String(attribute='precisions_sanitized')
 
 class RecommandationSchema(Schema):
     recommandation = fields.Function(
-        lambda recommandation, context: recommandation.format(context.get('commune'))
+        lambda recommandation, context: recommandation.format(context.get('commune')), swagger_type="string"
     )
     type = fields.String(attribute='type_')
 


### PR DESCRIPTION
Ceci provoquait une erreur qui empêchait de générer la documentation Swagger de l'API :
`ValueError: Must include "swagger_type" keyword argument in Function field`